### PR TITLE
Added the command aliases to the bukkit registration process

### DIFF
--- a/bukkit/src/main/java/io/github/revxrsal/cub/bukkit/core/BukkitHandledCommand.java
+++ b/bukkit/src/main/java/io/github/revxrsal/cub/bukkit/core/BukkitHandledCommand.java
@@ -80,6 +80,7 @@ class BukkitHandledCommand extends BaseHandledCommand implements io.github.revxr
             cmd.setExecutor(dispatcher);
             cmd.setTabCompleter(new BukkitTab(handler));
             cmd.setDescription(command.getDescription() == null ? "" : command.getDescription());
+            cmd.setAliases(command.getAliases());
         } catch (ReflectiveOperationException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
Hey,

I added that the command aliases get registered for bukkit.

This bug are still existing for cli and jda, for the reason that I always used discord.js for discord bots, I dont really now how to implement that also for jda.